### PR TITLE
Adds a method to evaluate the TD error for rlTD and rlQLearning

### DIFF
--- a/src/rlQLearning.hpp
+++ b/src/rlQLearning.hpp
@@ -91,16 +91,19 @@ namespace rl {
 
       virtual ~QLearning(void) {}
 
-      void learn(const STATE& s, const ACTION& a, double r,
-		 const STATE& s_, const ACTION& a_) {
+      virtual double td_error(const rl::sa::Pair<STATE,ACTION>& z,
+			      double r,
+			      const rl::sa::Pair<STATE,ACTION>& z_) override {
 	auto vv    = this->v;
 	auto tt    = this->theta;
-	auto qq_s_ = [&vv,&tt,&s_](ACTION aa) -> double {return vv(tt,{s_,aa});};
-	this->td_update({s,a},
-			r + this->gamma*rl::argmax(qq_s_,
-						   a_begin,
-						   a_end).second 
-			- vv(tt,{s,a}));
+	auto qq_s_ = [&vv,&tt,&z_](ACTION aa) -> double {return vv(tt,{z_.s,aa});};
+	return r + this->gamma*rl::argmax(qq_s_, a_begin, a_end).second - vv(tt, z);
+      }
+      
+      
+      void learn(const STATE& s, const ACTION& a, double r,
+		 const STATE& s_, const ACTION& a_) {
+	this->td_update({s,a}, this->td_error({s, a}, r, {s_, a_}));
       }
 
       void learn(const STATE& s, const ACTION& a, double r) {

--- a/src/rlTD.hpp
+++ b/src/rlTD.hpp
@@ -121,12 +121,20 @@ namespace rl {
 	gsl_vector_free(grad);
       }
 
+      virtual double td_error(const Z& z, double r, const Z& z_) {
+	return r + gamma*v(theta,z_) - v(theta,z);
+      }
+
+      virtual double td_error(const Z& z, double r) {
+	return r - v(theta,z);
+      }
+      
       void learn(const Z& z, double r, const Z& z_) {
-	this->td_update(z,r + gamma*v(theta,z_) - v(theta,z));
+	this->td_update(z,this->td_error(z, r, z_));
       }
 
       void learn(const Z& z, double r) {
-	this->td_update(z,r - v(theta,z));
+	this->td_update(z,this->td_error(z, r));
       }
 
       /**


### PR DESCRIPTION
It introduces methods to compute the TD error with the rlTD and rlQLearning algorithms. 

It might be useful to get such methods when, for example, these algorithms are used as critics in Actor Critic algorithms, for updating the parameters of the actor.